### PR TITLE
Corrected typo in application template, using div instead of p

### DIFF
--- a/source/projects/jsblogger.markdown
+++ b/source/projects/jsblogger.markdown
@@ -900,7 +900,7 @@ Looking at the default layout, you'll see this:
 The `yield` is where the view template content will be injected. Just *above* that yield, let's display the flash by adding this:
 
 ```erb
-<div class="flash"><%= flash[:message] %></div>
+<p class="flash"><%= flash[:message] %></p>
 ```
 
 This outputs the value stored in the `flash` object with the key `:message`.


### PR DESCRIPTION
Changed "<div class="flash"><%= flash[:message] %></div>" 

to "<p class="flash"><%= flash[:message] %></p>"

Modified it to be paragraph tag instead of div, as the style sheet is decorating p.flash.
