### PR TITLE
Fix Markdown formatting on "An if block has..." 

### DIFF
--- a/source/projects/ruby_in_100_minutes.markdown
+++ b/source/projects/ruby_in_100_minutes.markdown
@@ -459,6 +459,7 @@ When the `minutes` is 8, it goes like this: "Is it `true` that 8 is less than 7?
 Lastly, when total is 9, it goes: "Is it `true` that 9 is less than 7? No. Next, is it `true` that 9 is equal to 7? No. Next, is it `true` that 9 is equal to 8? No. Since none of those are true, execute the `else` and  print the line `Hot! Hot! Hot!`.
 
 An `if` block has...
+
 * One `if` statement whose instructions are executed only if the statement is true
 * Zero or more `elsif` statements whose instructions are executed only if the statement is true
 * Zero or one `else` statement whose instructions are executed if no `if` nor `elsif` statements were true


### PR DESCRIPTION
List was not displayed as it should be and generated text had become bit confusing compared to raw Markdown text file.
