### PR TITLE
Remove extra `end` in case command. Entering code as-is throws error

### DIFF
--- a/source/projects/jstwitter.markdown
+++ b/source/projects/jstwitter.markdown
@@ -208,7 +208,6 @@ Start with this case statement in your method just below the `command = gets.cho
     when 'q' then puts "Goodbye!"
     else
       puts "Sorry, I don't know how to #{command}"
-    end
   end
 ```
 


### PR DESCRIPTION
syntax error, unexpected keyword_end, expecting $end
