### PR TITLE
Update Comment create for Article show method

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -1109,7 +1109,8 @@ Remember how we created a blank `Article` object so Rails could figure out which
 But when we view the article and display the comment form we're not running the article's `new` method, we're running the `show` method. So we'll need to create a blank `Comment` object inside that `show` method like this:
 
 ```ruby
-@comment = @article.comments.new
+@comment = Comments.new
+@comment.article_id = @article.id
 ```
 
 We build it off the parent `@article` object just like we did in the console. That will automatically populate the `article_id` attribute of the new `Comment` with the `id` of the `Article`.


### PR DESCRIPTION
Due to https://github.com/rails/rails/pull/1437 the behavior of `article.comments.new` has changed. Instead of just creating a new `Comment`, it is aliased to `build`. Which per the documentation [ActiveRecord::Associations::ClassMethods#has_many collection.build](http://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#method-i-has_many) creates the new object and assigns it to the `@article` Comment collection.

This causes the partial rendering of the `distance_of_time_in_words` to fail with a no method on `nil`.

Additionally, it's not advised to use a one-liner (per notes in JumpstartLab/curriculum#61) `@comment = Comments.new(article_id: @article.id)` due to the `ActiveModel::MassAssignmentSecurity::Error`.
