### PR TITLE
FIX: Titles with special chars were blocking startup

### DIFF
--- a/source/academy/curriculum/resources/Week 2/Day 2/02_02_all?.markdown
+++ b/source/academy/curriculum/resources/Week 2/Day 2/02_02_all?.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: `all?`
+title: "`all?`"
 ---
 
 ## `all?`

--- a/source/academy/curriculum/resources/Week 2/Day 2/02_02_any?.markdown
+++ b/source/academy/curriculum/resources/Week 2/Day 2/02_02_any?.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: `any?`
+title: "`any?`"
 ---
 
 ## `any?`

--- a/source/academy/curriculum/resources/Week 2/Day 2/02_02_collect:map.markdown
+++ b/source/academy/curriculum/resources/Week 2/Day 2/02_02_collect:map.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: `collect` / `map`
+title: "`collect` / `map`"
 ---
 
 ## `collect` / `map`

--- a/source/academy/curriculum/resources/Week 2/Day 2/02_02_detect:find.markdown
+++ b/source/academy/curriculum/resources/Week 2/Day 2/02_02_detect:find.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: `detect` / `find`
+title: "`detect` / `find`"
 ---
 
 ## `detect` / `find`

--- a/source/academy/curriculum/resources/Week 2/Day 2/02_02_each with index.markdown
+++ b/source/academy/curriculum/resources/Week 2/Day 2/02_02_each with index.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: `each_with_index`
+title: "`each_with_index`"
 ---
 
 ## `each_with_index`

--- a/source/academy/curriculum/resources/Week 2/Day 2/02_02_enumerable.markdown
+++ b/source/academy/curriculum/resources/Week 2/Day 2/02_02_enumerable.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: `Enumberable`
+title: "`Enumberable`"
 ---
 
 ## `Enumberable`

--- a/source/academy/curriculum/resources/Week 2/Day 2/02_02_grep.markdown
+++ b/source/academy/curriculum/resources/Week 2/Day 2/02_02_grep.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: `grep`
+title: "`grep`"
 ---
 
 ## `grep`

--- a/source/academy/curriculum/resources/Week 2/Day 2/02_02_include?.markdown
+++ b/source/academy/curriculum/resources/Week 2/Day 2/02_02_include?.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: `include?`
+title: "`include?`"
 ---
 
 ## `include?`

--- a/source/academy/curriculum/resources/Week 2/Day 2/02_02_inject:reduce.markdown
+++ b/source/academy/curriculum/resources/Week 2/Day 2/02_02_inject:reduce.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: `inject` / `reduce`
+title: "`inject` / `reduce`"
 ---
 
 ## `inject` / `reduce`

--- a/source/academy/curriculum/resources/Week 2/Day 2/02_02_max:min.markdown
+++ b/source/academy/curriculum/resources/Week 2/Day 2/02_02_max:min.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: `max` / `min`
+title: "`max` / `min`"
 ---
 
 ## `max` / `min`

--- a/source/academy/curriculum/resources/Week 2/Day 2/02_02_max_by:min_by.markdown
+++ b/source/academy/curriculum/resources/Week 2/Day 2/02_02_max_by:min_by.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: `max_by` / `min_by`
+title: "`max_by` / `min_by`"
 ---
 
 ## `max_by` / `min_by`

--- a/source/academy/curriculum/resources/Week 2/Day 2/02_02_partition.markdown
+++ b/source/academy/curriculum/resources/Week 2/Day 2/02_02_partition.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: `partition`
+title: "`partition`"
 ---
 
 ## `partition`

--- a/source/academy/curriculum/resources/Week 2/Day 2/02_02_reject.markdown
+++ b/source/academy/curriculum/resources/Week 2/Day 2/02_02_reject.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: `reject`
+title: "`reject`"
 ---
 
 ## `reject`

--- a/source/academy/curriculum/resources/Week 2/Day 2/02_02_sort:sort_by.markdown
+++ b/source/academy/curriculum/resources/Week 2/Day 2/02_02_sort:sort_by.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: `sort` / `sort_by`
+title: "`sort` / `sort_by`"
 ---
 
 ## `sort` / `sort_by`

--- a/source/academy/curriculum/resources/Week 5/Day 1/05_01_drive small group.markdown
+++ b/source/academy/curriculum/resources/Week 5/Day 1/05_01_drive small group.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Drive" - Small Group 
+title: "\"Drive\" - Small Group"
 ---
 
 ## "Drive: The Surprising Truth About What Motivates Us" by Daniel H. Pink" Small Group Discussion

--- a/source/academy/curriculum/resources/Week 8/Day 1/08_01_inspired small group.markdown
+++ b/source/academy/curriculum/resources/Week 8/Day 1/08_01_inspired small group.markdown
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: "Inspired" - Small Group
+title: "\"Inspired\" - Small Group"
 ---
 
 ## ["Inspired"] by Marty Cagan: Small Group Discussions


### PR DESCRIPTION
I updated and then noticed that Jekyll `rake preview` was failed to
parse the content documents and threw out a YAML error.

Digging in deeper I found that it was not a configuration file but all
of the articles added with special characters that are not kosher to YAML
format. So I have updated all of the content items to incldue quotes
around the offending backticks which caused the issue.

Should it be this way or is this something unique to my setup?
