### PR TITLE
Refer to Sublime Text rather than RubyMine

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -36,7 +36,7 @@ From the command line, switch to the folder that will store your projects. For i
 rails new blogger
 ```
 
-Use `cd blogger` to change into the directory, then open it in your text editor. If you're using TextMate, run `mate .` or with RubyMine run `mine .`.
+Use `cd blogger` to change into the directory, then open it in your text editor. If you're using TextMate, run `mate .` or with Sublime Text run `subl .`.
 
 ### Project Tour
 
@@ -1424,7 +1424,7 @@ ActiveRecord::UnknownAttributeError in ArticlesController#create
 unknown attribute: tag_list
 ```
 
-What is this all about?  Let's start by looking at the form data that was posted when we clicked SAVE. This data is in the production.log file which should be in the "Console" frame at the bottom of the RubyMine window. Look for the line that starts "Processing ArticlesController#create", here's what mine looks like:
+What is this all about?  Let's start by looking at the form data that was posted when we clicked SAVE. This data is in the terminal where you are running the rails server. Look for the line that starts "Processing ArticlesController#create", here's what mine looks like:
 
 ```plain
 Processing ArticlesController#create (for 127.0.0.1) [POST]
@@ -1680,7 +1680,7 @@ In the past Rails plugins were distributed a zip or tar files that got stored in
 
 Most Rails plugins are now moving toward RubyGems. RubyGems is a package management system for Ruby, similar to how Linux distributions use Apt or RPM. There are central servers that host libraries, and we can install those libraries on our machine with a single command. RubyGems takes care of any dependencies, allows us to pick an options if necessary, and installs the library.
 
-Let's see it in action. If you have your server running in RubyMine, click the red square button to STOP it. If you have a console session open, type `exit` to exit. Then open up `Gemfile` and look for the lines like this:
+Let's see it in action. Go to your terminal where you have the rails server running, and type `Ctrl-C`. If you have a console session open, type `exit` to exit. Then open up `Gemfile` and look for the lines like this:
 
 ```ruby
 # To use ActiveModel has_secure_password
@@ -1699,7 +1699,7 @@ These lines are commented out because they start with the `#` character. By spec
   gem "paperclip"
 ```
 
-When you're writing a production application, you might specify additional parameters that require a specific version or a custom source for the library. With that config line declared, if using RubyMine, click the green arrow in RubyMine to startup your server. You should get an error like this:
+When you're writing a production application, you might specify additional parameters that require a specific version or a custom source for the library. With that config line declared, go back to your terminal and run `rails server` to start the application again. You should get an error like this:
 
 ```plain
   Could not find gem 'paperclip (>= 0, runtime)' in any of the gem sources listed in your Gemfile.
@@ -1786,7 +1786,7 @@ Then further down the form, right before the paragraph with the save button, let
 
 ### Trying it Out
 
-If your server isn't running, start it up (if using RubyMine, do this by pressing the green play button). Then go to `http://localhost:3000/articles/` and click EDIT for your first article. The file field should show up towards the bottom. Click the `Choose a File` and select a small image file (a suitable sample image can be found at http://hungryacademy.com/images/beast.png). Click SAVE and you'll return to the article index. Click the title of the article you just modified. What do you see?  Did the image attach to the article?
+If your server isn't running, start it up (`rails server` in your terminal). Then go to `http://localhost:3000/articles/` and click EDIT for your first article. The file field should show up towards the bottom. Click the `Choose a File` and select a small image file (a suitable sample image can be found at http://hungryacademy.com/images/beast.png). Click SAVE and you'll return to the article index. Click the title of the article you just modified. What do you see?  Did the image attach to the article?
 
 When I first did this, I wasn't sure it worked. Here's how I checked:
 
@@ -1854,7 +1854,7 @@ If it's so easy, why don't we do it right now?  The catch is that paperclip does
 
 I use another gem in every project: Haml. It's an alternative templating language to the default ERB (which you've been using, hence all the view templates ending in `.erb`). I also use Sass rather than plain old CSS, and it makes it much, much easier to work with.
 
-Open your `Gemfile` and add a `gem` line for the gem `haml-rails`. Go to your terminal and `bundle` and it should pull down the gem library for you. Stop, then restart your server (if using RubyMine, do this via the red square and green play button respectively). Haml is installed and ready to use. It will also now be used by the generators to create the template views. SASS should already have a line in your `Gemfile`, as it's included by default in Rails these days. It might also say `sass-rails`, which includes `sass`.
+Open your `Gemfile` and add a `gem` line for the gem `haml-rails`. Go to your terminal and `bundle` and it should pull down the gem library for you. Stop, then restart your server (in your terminal where the server is running, type `Ctrl-C`, and then type `rails server`). Haml is installed and ready to use. It will also now be used by the generators to create the template views. SASS should already have a line in your `Gemfile`, as it's included by default in Rails these days. It might also say `sass-rails`, which includes `sass`.
 
 Open up a new file in your `app/assets/stylesheets` directory called `styles.css.scss`. Let's write some!
 

--- a/source/projects/eventmanager.markdown
+++ b/source/projects/eventmanager.markdown
@@ -61,21 +61,7 @@ manager = EventManager.new
 
 ### Running the Program
 
-#### From Inside RubyMine
-
-In RubyMine, click the RUN menu at the top, then EDIT CONFIGURATIONS
-
-* Click the [+] icon
- * Click RUBY
- * Set the NAME to EventManager
-* Click the [...] next to RUBY SCRIPT and select your `event_manager.rb` file
-* Click the [...] next to WORKING DIRECTORY and select the folder where your `event_manager.rb` file is stored
-* Leave everything else alone and click OK
-* Click the RUN menu then RUN or Command-F8 to execute the program
-
-#### From the Terminal
-
-If you prefer to run the program from the terminal:
+In the terminal:
 
 {% terminal %}
 $ cd event_manager
@@ -168,7 +154,7 @@ manager = EventManager.new
 manager.print_names
 ```
 
-Then *run the program* using RubyMine or the terminal. You'll see that the `line` object looks like an Array.
+Then *run the program* using the terminal. You'll see that the `line` object looks like an Array.
 
 #### Default Reading
 

--- a/source/projects/ruby_in_100_minutes.markdown
+++ b/source/projects/ruby_in_100_minutes.markdown
@@ -169,7 +169,7 @@ While running simple commands in IRB is easy, it becomes tiresome to do anything
 
 * Exit your IRB session
 * Note which folder your terminal is currently in, this is your "working directory"
-* Using a plain-text editor like Notepad++, RubyMine, create a file named `personal_chef.rb`.
+* Using a plain-text editor like Notepad++ or Sublime Text, create a file named `personal_chef.rb`.
 * Save the file in your editor
 * Reopen `irb` from your terminal
 * Now load the file:

--- a/source/topics/debugging/debugger.markdown
+++ b/source/topics/debugging/debugger.markdown
@@ -186,7 +186,7 @@ The last command that you executed will be executed again by pressing the `retur
 
 ## IDE Support
 
-If using the debugger is rare, then using the debugger in an IDE must be the white elephant of Ruby development. But let's checkout how Rubymine tries to make using the debugger easier.
+If using the debugger is rare, then using the debugger in an IDE must be the white elephant of Ruby development. But let's checkout how RubyMine tries to make using the debugger easier.
 
 ### RubyMine Setup
 


### PR DESCRIPTION
Sublime Text 2 has replaced RubyMine as the simplest thing that could
possibly work across all platforms.

This means that ruby programs are run directly in the terminal rather
than in RubyMine's console.
- the Blogger project
- the EventManager project
- the Ruby in 100 Minutes tutorial

The RubyMine references have been left alone in the Debugging tutorial,
because it is clearly marked as being a rare and curious thing.

Also, it is left in the Environment section, as it is still a valid
choice of editor/IDE.

Fixes #103
