### PR TITLE
Form partial fix in Blogger tutorial

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -848,7 +848,7 @@ Add the following code to that view:
 <%= render :partial => 'form' %>
 ```
 
-Now go back to the `_form.html.erb` and paste the code from your clipboard. Change the text on the `submit` button to say "Save" so it makes sense both when creating a new article and editing an existing one.
+Now go back to the `_form.html.erb` and paste the code from your clipboard.
 
 #### Writing the Edit Template
 


### PR DESCRIPTION
The `new` and `edit` article forms in the Blogger project were similar, but not identical, since the edit form had error handling, but the create form did not.

Extracting into a partial makes more sense if the code is truly identical, and I erred on the side of keeping the error handling.

In the same section, there was an instruction to change the text of the submit button, which seems to have been referring to an earlier version of the tutorial. I went ahead and deleted it, which fixes #293.
