### PR TITLE
Changed reference to 'state_stats' to 'state_data'

### DIFF
--- a/source/projects/eventmanager.markdown
+++ b/source/projects/eventmanager.markdown
@@ -916,7 +916,7 @@ Let's start with state-based information. How many attendees are from each state
   end
 ```
 
-In the second line there we've created a *Hash* named `state_stats`.
+In the second line there we've created a *Hash* named `state_data`.
 
 ### Step 1: Counting with a Hash
 


### PR DESCRIPTION
Hi team,

This is Christian, one of the students in the Ruby class being held in MD.  I found what looked to be a mismatched reference in the lab we worked on in the afternoon, and wasn't sure how else to highlight in in github than with a pull request.
