### PR TITLE
Deleted second Customer.invoices requirement

### DIFF
--- a/source/projects/sales_engine.markdown
+++ b/source/projects/sales_engine.markdown
@@ -164,7 +164,6 @@ _NOTE_: All revenues should be reported as a `BigDecimal` object with two decima
 ##### `Customer`
 
 * `#transactions` returns an array of `Transaction` instances associated with the customer
-* `#invoices` returns an array of `Invoice` instances associated with the customer
 * `#favorite_merchant` returns an instance of `Merchant` where the customer has conducted the most successful transactions
 
 ##### `Invoice` - Creating New Invoices & Related Objects


### PR DESCRIPTION
In "Relationships", under "Customer" line 140, I see "#invoices returns a collection of Invoice instances associated with this object."

This is later repeated in "Business Intelligence", under "Customer" line 167. ("#invoices returns an array of Invoice instances associated with the customer"). These two appear to be identical requirements.
