### PR TITLE
fixed author_name method call in comment section of blogger.markdown

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -1106,7 +1106,7 @@ This renders a partial named `"comment"` and that we want to do it once for each
 
 ```erb
 <div>
-  <h4>Comment by <%= comment.author %></h4>
+  <h4>Comment by <%= comment.author_name %></h4>
   <p class="comment"><%= comment.body %></p>
 </div>
 ```


### PR DESCRIPTION
changed 'comment.author' to 'comment.author_name' on line 1109.
