### PR TITLE
Update traffic_spy.markdown

### DIFF
--- a/source/projects/traffic_spy.markdown
+++ b/source/projects/traffic_spy.markdown
@@ -118,7 +118,7 @@ payload = {
   "requestType":"GET",
   "parameters":[],
   "eventName": "socialLogin",
-  "userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17",
+  "userAgent":"Mozilla/5.0 (Macintosh, Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17",
   "resolutionWidth":"1920",
   "resolutionHeight":"1280",
   "ip":"63.29.38.211" }


### PR DESCRIPTION
Semicolon causes curl to cut off at 'Macintosh;'. So params[:payload] doesn't get the full request.
