### PR TITLE
Formal argument cannot be the class name

### DIFF
--- a/source/projects/ruby_in_100_minutes.markdown
+++ b/source/projects/ruby_in_100_minutes.markdown
@@ -284,7 +284,7 @@ $ frank.make_toast('burnt')
 ### Milkshake Flavors
 
 * Create a `make_milkshake` method, that has a flavor parameter,  
-  `PersonalChef`
+  `flavor`
 
 * In `irb` run the commands: 
 


### PR DESCRIPTION
Code will throw a Syntax Error if flavor parameter is named PersonalChef. 
Changed parameter name (was PersonalChef) to flavor.
