### PR TITLE
Details about ruby installation on Mac OS X Mountain Lion 

### DIFF
--- a/source/topics/environment/environment.markdown
+++ b/source/topics/environment/environment.markdown
@@ -18,8 +18,12 @@ The setup instructions are broken down by the following platforms: Mac; Linux; a
 Mac OS is the most popular platform for Ruby and Rails developers. To have a properly setup dev machine you want the following:
 
 ### OS X Mountain Lion
-* Install free XCode app from the Apple store. This app allows for the installation of the Comand Line Tools which are required for the successful installation of all ruby related content on Mac OS.
-* Once XCode app is installed, go to Preferences > Downloads > Install Comand Line Tools.
+* Install free XCode app from the Apple store. 
+  This app allows for the installation of the Comand Line Tools
+  which are required for the successful installation of all 
+  ruby related content on Mac OS.
+* Once XCode app is installed, 
+  go to Preferences > Downloads > Install Comand Line Tools.
 
 ### Other Mac OS versions
 ### Command Line Tools for XCode


### PR DESCRIPTION
I turns out that Max OS X Mountain Lion has updated way of installing Command Line Tools. In this OS Command Line Tools can be installed only through gui of the XCode app. I've updated this page to illustrate this change.
