### PR TITLE
Edit initial git commands

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -480,7 +480,8 @@ Next, [create a repository](https://github.com/new) for the project and on the c
 
 {% terminal %}
 $git init
-$git commit -a "first blogger commit"
+$git add .
+$git commit -m "first blogger commit"
 $git remote add origin git@github.com:your_github_username/your_repository_name.git
 $git push -u origin master
 {% endterminal %}


### PR DESCRIPTION
When running the initial git setup using git version 1.8.2 I received the error `fatal: Paths with -a does not make sense.`

This pull request adds one extra step (`git add .`) and modifies another to remove the error from the process.

:hamster: :heart: :fish: 
