### PR TITLE
Passed argument message instead of 'ENCRYPTED'

### DIFF
--- a/source/projects/encryptor.markdown
+++ b/source/projects/encryptor.markdown
@@ -1149,7 +1149,7 @@ class Encryptor
 
   def crack(message)
     supported_characters.count.times.collect do |attempt|
-      decrypt('ENCRYPTED',attempt)
+      decrypt(message,attempt)
     end
   end
 end


### PR DESCRIPTION
The message argument is actually what you are looking to pass not the hardcoded 'ENCRYPTED' string that was used in the previous example.
