### PR TITLE
Added a specific .ruby-gemset file.

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+jumpstart_curriculum


### PR DESCRIPTION
Once you bundle install (it's painless) everyone can be assured they are sync'ed to the same gemset and are not adding additional gems to their global or other name gemsets.

I can understand if you don't want to accept this pull request!  Just thought I would propose it as it helps me immensely.

I am pretty sure I could probably make this bundle install when you loaded the curriculum as well (if you hadn't previously).
