### PR TITLE
renamed created_at in decorator to created_at_presentation and used it in show view!

### DIFF
--- a/source/topics/decorators.markdown
+++ b/source/topics/decorators.markdown
@@ -75,7 +75,7 @@ Currently the show page just displays the raw `created_at` attribute. Often we w
 Let's override the `created_at` method in our decorator:
 
 ```ruby
-  def created_at_presentation
+  def formatted_created_at
     article.created_at.strftime("%m/%d/%Y - %H:%M")
   end
 ```
@@ -91,7 +91,7 @@ Now in the show.html.erb for the show view of Article you need to change the fol
 to:
 
 ```ruby
-<h4>Published <%= @article.created_at_presentation %></h4>
+<h4>Published <%= @article.formatted_created_at %></h4>
 ```
 
 Refresh the `show` in your browser and the date will be reformatted.


### PR DESCRIPTION
... in show!

Overriding the created_at, created some issues with "distance_of_time_in_words(@article.created_at, comment.created_at)" part of the show view! 
Since we are changing the created_at definition when we're using it in the calculation of time distance with comment, the return value of the new created_at method is being used which is not a proper UTC time for that method and that's why the result of time distance of comment.created_at and @article.created_at which was 1 day for the first comment before this change now is becoming 8 months! (The same for the rest of the comments)

Thanks,
