### PR TITLE
use *decorate_collection* instead of *decorate* on "articles" array.

### DIFF
--- a/source/topics/decorators.markdown
+++ b/source/topics/decorators.markdown
@@ -135,7 +135,7 @@ Let's tweak it a bit to decorate the collection:
 ```ruby
   def index
     articles, @tag = Article.search_by_tag_name(params[:tag])
-    @articles = ArticleDecorator.decorate(articles)
+    @articles = ArticleDecorator.decorate_collection(articles)
   end
 ```
 


### PR DESCRIPTION
Latest version of _Draper_ which is being installed in this tutorial (cause of gem 'draper' in Gemfile) does not have _decorate_ for collections anymore! It has a special method for collections called _decorate_collection_ which needs to be used!
- In this tutorial either things need to be updated based on the latest version of _Draper_ or the previous version which was used originally in this tutorial should be referenced in Gemfile explicitly!
- As I'm going through this tutorial I try to update things based on latest _Draper_ gem!
- Whichever way you prefer, of course :-)

Thanks,
