### PR TITLE
Change terminal snippet to download "Small Sample"

### DIFF
--- a/source/projects/eventmanager.markdown
+++ b/source/projects/eventmanager.markdown
@@ -98,10 +98,10 @@ Download the *[small sample](event_attendees.csv)* csv file and save it in the
 root of `event_manager` directory.
 
 {% terminal %}
-$ curl -o event_attendees.csv http://tutorials.jumpstartlab.com/assets/eventmanager/event_attendees.csv
+$ curl -o event_attendees.csv http://tutorials.jumpstartlab.com/projects/event_attendees.csv
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
-100  555k  100  555k    0     0   288k      0  0:00:01  0:00:01 --:--:--  448k
+100  2125  100  2125    0     0   3269      0 --:--:-- --:--:-- --:--:-- 12073
 {% endterminal %}
 
 


### PR DESCRIPTION
The link before I changed it was giving me the "Large Sample" file instead. It was a bit misleading since it has the same filename as the "Small Sample" file. I knew because I compared file sizes.
