### PR TITLE
insert <meta> tag into html and erb template

### DIFF
--- a/source/projects/eventmanager.markdown
+++ b/source/projects/eventmanager.markdown
@@ -955,7 +955,7 @@ Something that looks like:
 ```html
 <html>
 <head>
-  <meta http-equiv="content-type" content="text/html;charset=UTF-8" />
+  <meta charset='utf-8'>
   <title>Thank You!</title>
 </head>
 <body>
@@ -1175,7 +1175,7 @@ return to the application.
 ```erb
 <html>
 <head>
-  <meta http-equiv="content-type" content="text/html;charset=UTF-8" />
+  <meta charset='utf-8'>
   <title>Thank You!</title>
 </head>
 <body>


### PR DESCRIPTION
![screen shot 2013-06-09 at 2 20 32 pm](https://f.cloud.github.com/assets/2514159/629422/a0c24b24-d14a-11e2-8c0b-1c5d95ac9a9f.png)

This edit solves a problem encountered when members of Congress have accent characters (diacritic marks) in their names. Previously the generated html contained garbage (when run on ruby 1.9.3). I'm no expert and I'd love to hear about it if there's a more elegant solution.
