### PR TITLE
revise 'adds a new phone number' spec during lesson 12

### DIFF
--- a/source/projects/contact_manager.markdown
+++ b/source/projects/contact_manager.markdown
@@ -848,6 +848,7 @@ new phone number we end up back on the show page for the person, and that number
 it 'adds a new phone number' do
   page.click_link('Add phone number')
   page.fill_in('Number', with: '555-8888')
+  page.fill_in('Person', with: person.id)
   page.click_button('Create Phone number')
   expect(current_path).to eq(person_path(person))
   expect(page).to have_content('555-8888')


### PR DESCRIPTION
the 'adds a new phone number' spec in lesson 12 fails because the new phone_number view contains a number_field for person_id. The spec will run successfully after adding page.fill_in('Person', with: person.id).
