### PR TITLE
Update for Capybara 2.0 update and Ambiguous match error.

### DIFF
--- a/source/projects/contact_manager.markdown
+++ b/source/projects/contact_manager.markdown
@@ -984,7 +984,7 @@ it 'edits a phone number' do
   phone = person.phone_numbers.first
   old_number = phone.number
 
-  page.click_link('edit')
+  first(:link, 'edit').click
   page.fill_in('Number', with: '555-9191')
   page.click_button('Update Phone number')
   expect(current_path).to eq(person_path(person))


### PR DESCRIPTION
I get the following error when there are more than one phone numbers on a page. 

the person view edits a phone number
     Failure/Error: page.click_link('edit')
     Capybara::Ambiguous:
       Ambiguous match, found 2 elements matching link "edit"

I think since Capybara 2.0 update you have to specify that the first link gets clicked on, where as in the previous version that was the default behaviour. There's probably a better way of doing this but this solution worked for me.
