### PR TITLE
Add option to skip creation of tests with the default Test::Unit framework

### DIFF
--- a/source/projects/contact_manager.markdown
+++ b/source/projects/contact_manager.markdown
@@ -52,7 +52,7 @@ $ cd contact_manager
 {% endterminal %}
 
 <div class="note">
-<p>The `--skip-test-unit` option here appened to the **rails** command tells Rails not to generate a `test` directory associated with the default **Test::Unit** framework.</p>
+<p>The `--skip-test-unit` option here appended to the **rails** command tells Rails not to generate a `test` directory associated with the default **Test::Unit** framework.</p>
 </div>
 
 Open the project in your editor of choice.


### PR DESCRIPTION
For the purpose of this tutorial, because testing will be done with RSpec, wouldn't it be easier to append the `--skip-test-unit` option to avoid creating the `test` directory and all the associated files? And then we could remove line 87-97 of the article.
