### PR TITLE
Update Contact Manager/Haml

### DIFF
--- a/source/projects/contact_manager.markdown
+++ b/source/projects/contact_manager.markdown
@@ -1963,7 +1963,7 @@ Haml was created as a response to this question: "If we adopt whitespace a signi
 
 #### Get Haml Installed
 
-Open up your `Gemfile`, add the dependency on the `"haml"` gem, save it and run `bundle` from the command prompt. Restart your web server so it loads the new library.
+Open up your `Gemfile`, add `gem "haml", "~> 3.1.8"`, save it and run `bundle` from the command prompt. Restart your web server so it loads the new library.
 
 #### Refactor a View
 


### PR DESCRIPTION
In the section above **Write Less Markup** instructions were given to add a `to_s` method for the models. The erb file still lists company.name despite refactoring.

Changes: 
- Use to_s method on Company
- Add CSS class "actions" to ul
