### PR TITLE
Add note section for removing line that won't work in Rails 4

### DIFF
--- a/source/projects/contact_manager.markdown
+++ b/source/projects/contact_manager.markdown
@@ -389,6 +389,10 @@ Finished in 0.26058 seconds
 
 The test failed because it expected a person with no first name to be invalid, but instead it *was* valid. We can fix that by adding a validation for first name inside the model:
 
+<div class="note">
+<p>If you are using Rails 4 you will need to leave out the line beginning with `attr_accessible`.</p>
+</div>
+
 ```ruby
 class Person < ActiveRecord::Base
   attr_accessible :first_name, :last_name


### PR DESCRIPTION
With the `attr_accessible` line in it gives this error:

```
$ bundle exec rspec
c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/activemodel-4.0.0/lib/activ
e_model/deprecated_mass_assignment_security.rb:14:in `attr_accessible': `attr_ac
cessible` is extracted out of Rails into a gem. Please use new recommended prote
ction model for params(strong_parameters) or add `protected_attributes` to your
Gemfile to use old one. (RuntimeError)
    from c:/Users/blake/code/contact_manager_2/app/models/person.rb:2:in `<c
lass:Person>'
    from c:/Users/blake/code/contact_manager_2/app/models/person.rb:1:in `<t
op (required)>'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/activesupport-
4.0.0/lib/active_support/dependencies.rb:228:in `require'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/activesupport-
4.0.0/lib/active_support/dependencies.rb:228:in `block in require'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/activesupport-
4.0.0/lib/active_support/dependencies.rb:213:in `load_dependency'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/activesupport-
4.0.0/lib/active_support/dependencies.rb:228:in `require'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/activesupport-
4.0.0/lib/active_support/dependencies.rb:329:in `require_or_load'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/activesupport-
4.0.0/lib/active_support/dependencies.rb:462:in `load_missing_constant'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/activesupport-
4.0.0/lib/active_support/dependencies.rb:183:in `const_missing'
    from c:/Users/blake/code/contact_manager_2/spec/models/person_spec.rb:3:
in `<top (required)>'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/activesupport-
4.0.0/lib/active_support/dependencies.rb:222:in `load'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/activesupport-
4.0.0/lib/active_support/dependencies.rb:222:in `block in load'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/activesupport-
4.0.0/lib/active_support/dependencies.rb:213:in `load_dependency'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/activesupport-
4.0.0/lib/active_support/dependencies.rb:222:in `load'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/rspec-core-2.1
4.5/lib/rspec/core/configuration.rb:896:in `block in load_spec_files'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/rspec-core-2.1
4.5/lib/rspec/core/configuration.rb:896:in `each'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/rspec-core-2.1
4.5/lib/rspec/core/configuration.rb:896:in `load_spec_files'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/rspec-core-2.1
4.5/lib/rspec/core/command_line.rb:22:in `run'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/rspec-core-2.1
4.5/lib/rspec/core/runner.rb:80:in `run'
    from c:/RailsInstaller/Ruby2.0.0/lib/ruby/gems/2.0.0/gems/rspec-core-2.1
4.5/lib/rspec/core/runner.rb:17:in `block in autorun'
```

I believe the attr_accessible stuff is taken care of in the controller in Rails 4 so we might need to also update the controller to account for this.

Not sure if you want these Rails 4 specific changes in this tutorial or not?
