### PR TITLE
Ideabox fixes

### DIFF
--- a/source/projects/idea_box.markdown
+++ b/source/projects/idea_box.markdown
@@ -1901,8 +1901,8 @@ hash by default if nothing is provided:
 
 ```ruby
 def initialize(attributes = {})
-  @title = attributes[:title]
-  @description = attributes[:description]
+  @title = attributes["title"]
+  @description = attributes["description"]
 end
 ```
 


### PR DESCRIPTION
Web Guesser had verbiage regarding WEBrick as well - though I saw on Jeff's machine and my own machine that Thin was used. This was only because we had thin installed --- Sinatra still defaults to WEBrick.
