### PR TITLE
Update blogger.markdown

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -1520,7 +1520,6 @@ Another alternative is to define a new `Tag#to_s` method which overrides the def
 
 ```ruby
 class Tag < ActiveRecord::Base
-  attr_accessible :name
 
   has_many :taggings
   has_many :articles, through: :taggings


### PR DESCRIPTION
attr_accessible was replaced with strong params in Rails 4. This code works without it.
