### PR TITLE
Remove outdated call to add edit link.

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -2416,8 +2416,6 @@ Open `app/views/articles/show.html.erb` and find the section where we output the
 
 Look at the article listing in your browser when you're logged out and make sure those links disappear. Then use the same technique to hide the "Create a New Article" link. Similarly, hide the 'delete' link for the tags index.
 
-If you look at the `show` view template, you'll see that we never added an edit link!  Add that link now, but protect it to only show up when a user is logged in.
-
 Your basic authentication is done, and Iteration 5 is complete!
 
 ### Extra Credit


### PR DESCRIPTION
Removed the call to add an edit link and protect it. The link was created on line 846 of the tutorial, under #### Adding the Edit Link.
Protection was created two paragraphs before the deletion.
