### PR TITLE
Add Capybara DSL and URL Helpers to test_helper.rb

### DIFF
--- a/source/topics/capybara/essentials.markdown
+++ b/source/topics/capybara/essentials.markdown
@@ -27,6 +27,9 @@ For a Rails application, the setup is simple. Before your tests run you need to 
 
 ```
 require 'capybara/rails'
+
+include Capybara::DSL
+include Rails.application.routes.url_helpers
 ```
 
 ### Reference


### PR DESCRIPTION
Lines like `79` will break without the Capybara DSL and URL helpers. Found this out while striving to test our Dinner Dash.
