### PR TITLE
blogger SASS example should use a nested rule instead of a nested property

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -1962,7 +1962,7 @@ body {
 
 a {
   color: #0000FF;
-  img: {
+  img {
     border: none;
   }
 }


### PR DESCRIPTION
In the 'Blogger' Sass examples, the nested 'img' tag is used as a nested property but it should be a nested rule.
