### PR TITLE
Added sentence for clarity.

### DIFF
--- a/source/topics/performance/queries.markdown
+++ b/source/topics/performance/queries.markdown
@@ -267,7 +267,7 @@ Continuing with our previous example, suppose we always want the comments for an
 default_scope include: {comments: :approval}
 ```
 
-After the above has been added to the model, then `Article.find(1)` will include the associated `comments`.  
+After the above has been added to the model, then `Article.find(1)` will include the associated `comments`. Therefore, if you need that article's comments, another database query is no longer necessary.
 
 `default_scope` has the drawback that this `:include` will *ALWAYS* be included in any fetch of an `Article` object by default.  
 


### PR DESCRIPTION
I was confused that the Article.find(1) did not return the article's comments, but rather only the single article object. If you want to return the comments, you can do a = Article.find(1) which runs the database queries (to include the comments) followed by a.comments which returns all of that article's comments, but does not need to run another SQL query to do it.
