### PR TITLE
Multiple people placed each block inside the partial

### DIFF
--- a/source/topics/performance/digest_based_caching.markdown
+++ b/source/topics/performance/digest_based_caching.markdown
@@ -341,7 +341,7 @@ Nothing yet.
 
 #### Extracting a Partial
 
-Find the part of the view template that renders the comments using `@article.comments.each`. Cut the whole segment out to a partial:
+Find the part of the view template that renders the comments using `@article.comments.each`. Cut the segment inside of the each block out to a partial:
 
 ```html+erb
 <%= render partial: 'comments/comment', collection: @article.comments %>
@@ -358,6 +358,8 @@ and in `app/views/comments/_comment.html.erb`:
   <p><%= comment.body %></p>
 </div>
 ```
+
+If you're seeing the comments repeating over and over again after refreshing the show page, make sure you've deleted the each block that previously surrounded the portion you cut out. 
 
 #### Reevaluating Dependencies
 


### PR DESCRIPTION
When we cut the comments out to the partial and left in the @article.comments.each block, it looped through the collection twice, spitting out all the comments on the show page over and over again.
