### PR TITLE
Fix node.js package name for Ubuntu

### DIFF
--- a/source/topics/environment/environment.markdown
+++ b/source/topics/environment/environment.markdown
@@ -340,7 +340,7 @@ Instead, setup RVM and handle everything through there (as we'll discuss in the 
 
 If you're going to be doing Rails work, then you should also install Node.js. You can get it from your distribution's package manager. If you're using Ubuntu, like above:
 
-`sudo apt-get install node`
+`sudo apt-get install nodejs`
 
 ### Text Editor
 


### PR DESCRIPTION
I'm learning rails quickly thanks to your tutorials, but I think this change would have spared me a problem with node.js.

More changes are required if a recent version of node.js is needed.  See https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager for details.
