### PR TITLE
Fix markdown syntax error for `confirm_order_path'

### DIFF
--- a/source/projects/merchant.markdown
+++ b/source/projects/merchant.markdown
@@ -2161,8 +2161,8 @@ Lastly, we want to redirect to a thank you page with an order summary.
 format.html { redirect_to confirm_order_path(@order) }
 ```
 
-If you submit an order, you'll get an `undefined local variable or method
-`confirm_order_path'` error.
+If you submit an order, you'll get an
+``undefined local variable or method `confirm_order_path'`` error.
 
 Open up `config/routes.rb` and update the resources for orders:
 


### PR DESCRIPTION
The markdown syntax has an error and the formatting of the rails error message is messed up.
