### PR TITLE
changed jsblogger_advanced to blogger_advanced.

### DIFF
--- a/source/topics/asynchronous_data_with_faye.markdown
+++ b/source/topics/asynchronous_data_with_faye.markdown
@@ -92,7 +92,7 @@ Let's all practice working with Faye. Break into your groups and:
 
 1. Watch and *work through* the Faye episode on RailsCasts: http://railscasts.com/episodes/260-messaging-with-faye
 2. Watch and *work through* the PrivatePub episode on RailsCasts: http://railscasts.com/episodes/316-private-pub
-3. Implement pub/sub on JSBlogger (`git://github.com/JumpstartLab/jsblogger_advanced.git`) so that the dashboard is automatically updated when new articles or comments are added.
+3. Implement pub/sub on JSBlogger (`git://github.com/JumpstartLab/blogger_advanced.git`) so that the dashboard is automatically updated when new articles or comments are added.
 
 #### Other Links of Note
 


### PR DESCRIPTION
The git link was not working as git://github.com/JumpstartLab/jsblogger_advanced.git so I changed it to git://github.com/JumpstartLab/blogger_advanced.git
