### PR TITLE
Update Blogger => Paperclip 4.0 Validation

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -1837,13 +1837,16 @@ Then go to your terminal and run `rake db:migrate`. The rake command should show
 
 ### Adding to the Model
 
-The gem is loaded, the database is ready, but we need to tell our Rails application about the image attachment we want to add. Open `app/models/article.rb` and just below the existing `has_many` lines, add this line:
+The gem is loaded, the database is ready, but we need to tell our Rails application about the image attachment we want to add. Open `app/models/article.rb` and just below the existing `has_many` lines, add these lines:
 
 ```ruby
 has_attached_file :image
+validates_attachment_content_type :image, :content_type => ["image/jpg", "image/jpeg", "image/png"]
 ```
 
 This `has_attached_file` method is part of the paperclip library. With that declaration, paperclip will understand that this model should accept a file attachment and that there are fields to store information about that file which start with `image_` in this model's database table.
+
+As of version 4.0, all attachments are required to include a content_type validation, a file_name validation, or to explicitly state that they're not going to have either. Paperclip raises MissingRequiredValidatorError error if you do not do this. So, we add the validates_attachment_content_type line so that our model will validate that it is receiving a proper filetype.
 
 We also have to deal with mass assignment! Modify your `app/helpers/articles_helper.rb` and update the `article_params` method to permit an `:image` as:
 


### PR DESCRIPTION
Paperclip version 4.0 requires validations on filetypes, or to be explicitly told not to validate. Without adding validation, an error is raised and the user cannot continue. Added the validation and an explanation as to why it is necessary.
