### PR TITLE
Fix a few typos in the ideabox lesson.

### DIFF
--- a/source/projects/idea_box.markdown
+++ b/source/projects/idea_box.markdown
@@ -1792,7 +1792,7 @@ We need to update the `initialize` and `save` methods in `idea.rb` to use
 strings for the hash keys instead of symbols:
 
 ```ruby
-def initialize(attributes = {})
+def initialize(attributes)
   @title = attributes["title"]
   @description = attributes["description"]
 end


### PR DESCRIPTION
- Remove attributes taking an empty hash …
  This should be removed here because the app needs to fail on line #1884 so we add the empty hash on line #1903

These objects don't show up in the markdown unless they are properly `quoted`
