### PR TITLE
Event manager - Remove unnecessary returning index

### DIFF
--- a/source/projects/eventmanager.markdown
+++ b/source/projects/eventmanager.markdown
@@ -291,7 +291,6 @@ lines.each_with_index do |line,index|
   columns = line.split(",")
   name = columns[2]
   puts name
-  index
 end
 ```
 


### PR DESCRIPTION
Caused a bit of confusion during training as to whether index was necessary to return
