### PR TITLE
add username when creating Author

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -2181,7 +2181,7 @@ Author model. We could define them again manually as we did with Article.
 Instead we are going to rely on the Rails code controller scaffold generator.
 
 {% terminal %}
-$ bin/rails generate scaffold_controller Author email:string password:password password_confirmation:password
+$ bin/rails generate scaffold_controller Author username:string email:string password:password password_confirmation:password
 {% endterminal %}
 
 Rails has two scaffold generators: **scaffold** and **scaffold_controller**.


### PR DESCRIPTION
Author model has a not nullable field named 'username', so I guess it should be created with the scaffold_controller generator.
