### PR TITLE
Update vagrant_setup.markdown

### DIFF
--- a/source/topics/vagrant_setup.markdown
+++ b/source/topics/vagrant_setup.markdown
@@ -119,7 +119,7 @@ $ sudo apt-get install postgresql libpq-dev
 Postgres uses information from the operating system to determine the language and encoding of databases. Let's set that default locale now:
 
 {% terminal %}
-$ /usr/sbin/update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
+$ sudo /usr/sbin/update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 {% endterminal %}
 
 #### Creating the Database Instance & Adding a User


### PR DESCRIPTION
I needed to run `/usr/sbin/update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8` as sudo in order for the changes to take effect as permission was denied.
