### PR TITLE
Update jsrights.markdown

### DIFF
--- a/source/projects/javascript/jquery/jsrights.markdown
+++ b/source/projects/javascript/jquery/jsrights.markdown
@@ -141,9 +141,9 @@ p{
   margin: 5px 0px 5px 0px;
 }
 
-ul#toc{
-  margin-left: 20px;
-  font-size: 80%;
+ul#toc_list{
+  margin-left: -30px;
+  list-style: none;
 }
 ```
 
@@ -226,14 +226,26 @@ Jumping back to the top is great and all, but what most users are going to want 
 1. Create a ToC heading and unordered list near the top of the page
 1. Find all the `h2`s, they are the names of the articles
 1. Insert the article names as list items into the UL
-1. Insert named anchors into each of the `h2`s
+1. Insert `id` anchors into each of the `h2`s
 1. Link the Table of Contents item to the `h2`
 
 #### Create a ToC Heading and Unordered List
 
-We've already practiced creating a variable to hold HTML then inserting that HTML.  Store `"<h2 id='toc'><a name='toc'>Table of Contents</a></h2>"` into a variable and insert it into the markup just below the existing H1.  Instead of using `append` like we did before, here you need `after` so it goes outside the closing H1 tag.
+We've already practiced creating a variable to hold HTML then inserting that HTML.  Store `"<h2 id='toc_header'>Table of Contents</h2>"` into a variable and insert it into the markup just below the existing H1.  Instead of using `append` like we did before, here you need `after` so it goes outside the closing H1 tag.
 
-Then, just under that heading, insert an unordered list (UL) with the id attribute set to `'toc'`.  The tricky thing here is that you probably want to use a selector to find the ToC `h2`, but how can we do that without getting all the `h2`s? Use the CSS-style virtual attribute `:first` like `h2:first`.
+Then, just under that heading, insert an unordered list (UL) with the id attribute set to `'toc_list'`.  The tricky thing here is that you probably want to use a selector to find the ToC `h2`, but how can we do that without getting all the `h2`s? Use the CSS-style virtual attribute `:first` like `h2:first`.
+
+##### About `id`s
+The id attribute provides a unique identifier for an element within the document. 
+The most important aspect of the id attribute is that it must be absolutely unique. Unlike the class attribute, which may apply the same value to many elements in a page, an id that’s applied to an element must not match an id used anywhere else on the same page.
+Note that the id attribute cannot be applied to the following elements:
+`base`
+`head`
+`html`
+`meta`
+`script`
+`style`
+`title`
 
 Refresh the page in your browser, use the Inspect Element tool, and make sure your new HTML is getting injected properly.
 
@@ -277,14 +289,14 @@ Now refresh your page and you should see a bunch of popups with the individual a
 var listItem = "<li>" + title + "</li>";
 ```
 
-Then, on your own, write a selector to find the ToC UL and `append` the `list_item`.  Refresh your browser and you should see a plain text Table of Contents.
+Then, on your own, write a selector to find the ToC UL and `append` the `listItem`.  Refresh your browser and you should see a plain text Table of Contents.
 
 #### Linking
 
 Our ToC is nice for reading and printing, but it should be linked.  We want to click on an article title in the ToC and jump to the article further down the page.  To accomplish this interaction we need to:
 
 1. Take the title and convert it to a "slug" usable in a URL
-1. Insert anchors in the individual article `h2`s which have the name set to that slug
+1. Insert anchors in the individual article `h2`s which have the `id` set to that slug
 1. Link the list items in the ToC to that slug
 
 ##### Creating a Slug
@@ -317,27 +329,17 @@ Refresh your browser to check that the slugs look good and we can move on.
 
 ##### Insert the Target Anchors
 
-Now that we have the slug we can setup the target anchors.  Within the `each` block that we've been working in, remember that `this` is referring to the `h2`.  We want to inject the anchor inside that `h2`.  Let's create the anchor in one step, then insert it in a second like this:
+Now that we have the slug we can setup the target anchors.  Within the `each` block that we've been working in, remember that `this` is referring to the `h2`.  We want to inject the anchor inside that `h2`.  Let's create the anchor and insert it in one step. We'll use a handy jQuery method called `attr`. We'll call `attr` on the jQuery version of `this`, which remember represents each of our `h2`s. And then we'll pass two arguments to `attr`, the first of which declares the attribute we want to add: `id`, the second argument is the value of that attribute, which in our case is the previously defined variable slug.
 
 ```javascript
-var targetAnchor = "<a name='" + slug + "'/>";
+$(this).attr('id', slug);
 ```
-
-Then, on your own, use the `append` method to stick this inside the `h2`.  Remember that `self` is a pure Javascript object and it doesn't have an `append` method.
 
 ##### Link to the Targets
 
-We need to add links into the `list_item`.  On your own, work with the `var list_item=` line to include a link tag where the `href` points to `#article_x` where `article_x` is the current slug.
+We need to add links into the `listItem`.  On your own, work with the `var list_item=` line to include a link tag where the `href` points to `#article_x` where `article_x` is the current slug.
 
 Remove any `alert` lines you have and refresh your browser.  Your ToC should be fully functional!
-
-#### A Little Usability Issue
-
-How browsers handle anchor tags within pages varies.  In Chrome it jumps to the section of the page just below the anchor.  So in this case the links are working, but the anchor and `h2` showing the article title end up just out of view off the top of the screen.
-
-Here's a quick fix: if we know the browser is going to jump right below the anchor, let's put the anchor before the `h2` title.  Switch your `append` to `before` to make this happen.  Now when you refresh the browser and click a link the `h2` should be at the top of the window.
-
-This iteration is done!
 
 ### 5. Hiding Content
 


### PR DESCRIPTION
Made some updates for anchors, as html 5 doesn't use the 'name' attribute anymore. Just id's and those should always be unique. Also, append doesn't work per the original instructions in one of the scenarios, so I updated and introduced the 'attr' method. And then just tweaked a couple other minor things for consistency and/or style. 

Obviously - feel free to edit my edits. :smile: 
