### PR TITLE
Pass an argument to block for 'delete'

### DIFF
--- a/source/projects/idea_box.markdown
+++ b/source/projects/idea_box.markdown
@@ -1269,8 +1269,8 @@ We can fix this by adding a `delete` method in `idea.rb`:
 ```ruby
 class Idea
   def self.delete(position)
-    database.transaction do
-      database['ideas'].delete_at(position)
+    database.transaction do **|db|**
+      db['ideas'].delete_at(position)
     end
   end
 end


### PR DESCRIPTION
I couldn't get past an error saying "PStore::Error at /0" saying that it couldn't delete my idea w/ an id of 0 from my database. We weren't passing anything into that method as a param...the change to the code below has it working. (see below)
### Add `delete` to `Idea`

We can fix this by adding a `delete` method in `idea.rb`:

``` ruby
class Idea
  def self.delete(position)
    database.transaction do **|db|**
      db['ideas'].delete_at(position)
    end
  end
end
```
