### PR TITLE
Include contents of "Article#new" action

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -499,7 +499,7 @@ First let's create that action. Open `app/controllers/articles_controller.rb` an
 
 ```ruby
 def new
-
+  @article = Article.new
 end
 ```
 


### PR DESCRIPTION
The current page does not include the actual contents of the "Article#new" action definition. This raises an error when the form_for() method is called within the view.
