### PR TITLE
Update blogger.markdown

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -656,13 +656,13 @@ def create
 end
 ```
 
-If you refresh the page in your browser you'll still get the template error. Add one more line to the action, the redirect:
+If you refresh the page in your browser you'll still get the template error. Add one more line to the action, the redire
 
 ```ruby
 redirect_to article_path(@article)
 ```
 
-Refresh the page and you should go to the show for your new article. (_NOTE_: You've now created the same sample article twice)
+Refresh the page and you should go to the show for your new article. (_NOTE_: You've now created the same sample article twice). If redirect_to_article_path(@article) does not not work, try redirect_to(@article).
 
 #### More Body
 


### PR DESCRIPTION
In line #665, added this new line, "If redirect_to_article_path(@article) does not not work, try redirect_to(@article)." redirect_to_article_path(@article) didn't work on my machine. I am guessing this command works based on Ruby version. I have this version: ruby 2.0.0p481 (2014-05-08 revision 45883) [universal.x86_64-darwin13]. I was getting the error message that the command does not exist. But, changing the command to redirect_to(@article) worked.
