### PR TITLE
Contact Manager: Delete or change this line

### DIFF
--- a/source/projects/contact_manager.markdown
+++ b/source/projects/contact_manager.markdown
@@ -1980,7 +1980,6 @@ Let's make a similar set of changes to `app/views/companies/show.html.erb`...
 * Remove the paragraph with the company name
 * Make sure the phone numbers just renders the partial (not wrapped in a paragraph etc.)
 * Do the same for the email addresses
-* Change the actions so they're inside `li` tags inside a `ul` with the class name `"actions"`
 * Wrap the whole view in a div with class name `"company"`
 
 Run your tests and they should be green. Then, *repeat the process* for `app/views/people/show.html.erb`


### PR DESCRIPTION
I'm not sure if this line should be deleted or changed, but it's unclear which things it's referring to as actions in the company show page.

We already made something called an actions class in the company index page, which refers to the links to 'show', 'edit' and 'destroy' for each company.

In the context of the show page, I'm unclear as to whether it means only the 'edit' link, or if it means the 'add phone number', 'add email address' and 'edit' links, or if it means something else. I also think the way we have the links to those things separated by pipes looks better than a list. :p

So, not sure how this should be changed, but I'm quite unclear as to what it actually means anyway, so I do think it probably should be changed.