### PR TITLE
Update sessions_and_conversations.markdown

### DIFF
--- a/source/topics/controllers/sessions_and_conversations.markdown
+++ b/source/topics/controllers/sessions_and_conversations.markdown
@@ -114,7 +114,7 @@ bundle
 Next, create a migration to build the database table. From your command prompt:
 
 {% terminal %}
-$ rails generate session_migration
+$ rails generate active_record:session_migration
 $ rake db:migrate
 {% endterminal %}
 


### PR DESCRIPTION
I googled this shit and it's now `rails generate active_record:session_migration` in rails 4
