### PR TITLE
'require erb' in the Bitly section of the Microblogger project

### DIFF
--- a/source/projects/microblogger.markdown
+++ b/source/projects/microblogger.markdown
@@ -599,6 +599,7 @@ Next, open `irb` and try out the following:
 
 ```ruby
 require 'bitly'
+require 'erb'
 
 Bitly.use_api_version_3
 


### PR DESCRIPTION
An issue with HTTParty has recently popped up:
https://github.com/jnunemaker/httparty/issues/398

Requiring erb fixes the issue (for now I guess?).

Apologies for any breaches of etiquette, this is my first pull request.