### PR TITLE
Fix IRB sample hash fetch example

### DIFF
--- a/source/topics/performance/caching_data.markdown
+++ b/source/topics/performance/caching_data.markdown
@@ -307,7 +307,7 @@ We created the `sample` hash with no keys, so asking for `sample["count"]` would
 **But**, it doesn't store that value. So if you now ask for the key again the normal way:
 
 {% irb %}
-irb > cache["count"]
+irb > sample["count"]
 => nil
 {% endirb %}
 


### PR DESCRIPTION
I believe cache["count"] is meant to be sample["count"] so it is consistent with the hash above.