### PR TITLE
Remove Enrollment Files

### DIFF
--- a/source/projects/headcount/iteration_2.markdown
+++ b/source/projects/headcount/iteration_2.markdown
@@ -22,10 +22,6 @@ The repository is initialized and used like this:
 ```ruby
 str = StatewideTestRepository.new
 str.load_data({
-  :enrollment => {
-    :kindergarten => "./data/Kindergartners in full-day program.csv",
-    :high_school_graduation => "./data/High school graduation rates.csv"
-  },
   :statewide_testing => {
     :third_grade => "./data/3rd grade students scoring proficient or above on the CSAP_TCAP.csv",
     :eigth_grade => "./data/8th grade students scoring proficient or above on the CSAP_TCAP.csv",


### PR DESCRIPTION
Statewide Testing Repo should not be loading the Enrollment files, so these lines can be removed from the example.