### PR TITLE
Fixed spelling error in eighth_grade key

### DIFF
--- a/source/projects/headcount/iteration_2.markdown
+++ b/source/projects/headcount/iteration_2.markdown
@@ -24,7 +24,7 @@ str = StatewideTestRepository.new
 str.load_data({
   :statewide_testing => {
     :third_grade => "./data/3rd grade students scoring proficient or above on the CSAP_TCAP.csv",
-    :eigth_grade => "./data/8th grade students scoring proficient or above on the CSAP_TCAP.csv",
+    :eighth_grade => "./data/8th grade students scoring proficient or above on the CSAP_TCAP.csv",
     :math => "./data/Average proficiency on the CSAP_TCAP by race_ethnicity_ Math.csv",
     :reading => "./data/Average proficiency on the CSAP_TCAP by race_ethnicity_ Reading.csv",
     :writing => "./data/Average proficiency on the CSAP_TCAP by race_ethnicity_ Writing.csv"


### PR DESCRIPTION
Fixed spelling error in the eighth_grade file key.

`:eighth_grade => "./data/8th grade students scoring proficient or above on the CSAP_TCAP.csv",`

