### PR TITLE
Update method name

### DIFF
--- a/source/projects/headcount/iteration_3.markdown
+++ b/source/projects/headcount/iteration_3.markdown
@@ -66,9 +66,9 @@ The method returns an integer.
 *Example*:
 
 ```ruby
-economic_profile.median_household_income_in_year(2005)
+economic_profile.estimated_median_household_income_in_year(2005)
 => 50000
-economic_profile.median_household_income_in_year(2009)
+economic_profile.estimated_median_household_income_in_year(2009)
 => 55000
 ```
 


### PR DESCRIPTION
Method estimated_median_household_income_in_year was listed in the portion below it as median_household_income_in_year so I added the 'estimated' part back in.