### PR TITLE
Fix free_or_reduced_price_lunch_number_in_year

### DIFF
--- a/source/projects/headcount/iteration_3.markdown
+++ b/source/projects/headcount/iteration_3.markdown
@@ -133,7 +133,7 @@ on Free or Reduced Price Lunch in that year.
 *Example*:
 
 ```ruby
-economic_profile.free_or_reduced_price_lunch_total_in_year(2012)
+economic_profile.free_or_reduced_price_lunch_number_in_year(2012)
 => 100
 ```
 


### PR DESCRIPTION
Title called for free_or_reduced_price_lunch_number_in_year but below it it calls lunch_total instead.