### PR TITLE
Update iteration_1.markdown

### DIFF
--- a/source/projects/black_thursday/iteration_1.markdown
+++ b/source/projects/black_thursday/iteration_1.markdown
@@ -69,8 +69,8 @@ sa.average_price_per_merchant # => BigDecimal
 
 ### Which are our *Golden Items*?
 
-Given that our platform is going to charge merchants based on their sales, expensive items are extra exciting to us. Which are our "Golden Items", those two standard-deviations above the average item price?
+Given that our platform is going to charge merchants based on their sales, expensive items are extra exciting to us. Which are our "Golden Items", those two standard-deviations above the average item price? Return the item objects of these "Golden Items".
 
 ```ruby
-sa.golden_items # => [item, item, item, item]
+sa.golden_items # => [<item>, <item>, <item>, <item>]
 ```


### PR DESCRIPTION
Golden items seems to want item objects in the spec harness. That wasn't clear at all to me in this run-down.