### PR TITLE
invoice pending / successful

### DIFF
--- a/source/projects/black_thursday/iteration_4.markdown
+++ b/source/projects/black_thursday/iteration_4.markdown
@@ -34,7 +34,7 @@ sa = SalesAnalyst.new
 sa.merchants_with_pending_invoices #=> [merchant, merchant, merchant]
 ```
 
-**Note:** an invoice is considered pending if one or more of it’s transactions are not successful.
+**Note:** an invoice is considered pending if none of its transactions are successful.
 
 Which merchants offer only one item:
 


### PR DESCRIPTION
During the instructor pairing Andrew let us know that if a single transaction is successful the invoice has then been paid in full. He then went on to randomize the data so that many invoices had one transaction that was failing and one that was successful. 

So we were modeling invoice success as follows:
`invoice.transactions [success, failed, success] => paid_in_full? = true`
`invoice.transactions [failed] => paid_in_full? = false`

This led us to assume that `invoice.paid_in_full?` should dictate whether or not an invoice was considered pending
Let us know if our thought process is off

Yours - Blur / BearClaw