### PR TITLE
Swap two lines in show.html.erb to prevent error

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -1179,11 +1179,11 @@ You'll see that the article has associated comments. Now we need to integrate th
 
 ### Displaying Comments for an Article
 
-We want to display any comments underneath their parent article. Open `app/views/articles/show.html.erb` and add the following lines right before the link to the articles list:
+We want to display any comments underneath their parent article. Open `app/views/articles/show.html.erb` and add the following lines right after the link to the articles list:
 
 ```erb
-<h3>Comments</h3>
 <%= render partial: 'articles/comment', collection: @article.comments.reverse %>
+<h3>Comments</h3>
 ```
 
 This renders a partial named `"comment"` and that we want to do it once for each element in the collection `@article.comments`. We saw in the console that when we call the `.comments` method on an article we'll get back an array of its associated comment objects. This render line will pass each element of that array one at a time into the partial named `"comment"`. Now we need to create the file `app/views/articles/_comment.html.erb` and add this code:


### PR DESCRIPTION
If <%= render partial: 'articles/comment', collection: @article.comments.reverse %> comes after <h3>Comments</h3>, the error "undefined method `name' for nil:NilClass" is raised later in the tutorial when (<%= @article.comments.size %>) is added to the header. Swapping the order of the the header and render partial prevents this error. I am a rails beginner, so perhaps I am missing something.