### PR TITLE
improved naming in jungle_beats

### DIFF
--- a/source/projects/jungle_beat.markdown
+++ b/source/projects/jungle_beat.markdown
@@ -53,7 +53,7 @@ The three nodes here hold the data "hello", "world", and "!". The first two node
 ## Base Expectations
 
 * [Iteration 0](jungle_beat/iteration_0.md) - Node Basics
-* [Iteration 1](jungle_beat/iteration_1.md) - Append, All and Count (Single Node)
+* [Iteration 1](jungle_beat/iteration_1.md) - Append, To_string and Count (Single Node)
 * [Iteration 2](jungle_beat/iteration_2.md) - Append, Prepend and Insert (Multiple Nodes)
 * [Iteration 3](jungle_beat/iteration_3.md) - Managing Nodes
 * [Iteration 4](jungle_beat/iteration_4.md) - Creating a Linked List Wrapper
@@ -64,7 +64,7 @@ The three nodes here hold the data "hello", "world", and "!". The first two node
 
 * `append` an element to the end of the list
 * `prepend` an element at the beginning of the list
-* `all` return all elements in the linked list in order
+* `to_string` return all elements in the linked list in order
 * `insert` one or more elements at an arbitrary position in the list
 * `includes?` gives back `true` or `false` whether the supplied value is in the list
 * `pop` one or more elements from the end of the list

--- a/source/projects/jungle_beat/iteration_1.md
+++ b/source/projects/jungle_beat/iteration_1.md
@@ -1,4 +1,4 @@
-# Iteration 1 - Append, All and Count
+# Iteration 1 - Append, To_String and Count
 
 Great! We have nodes. Next step is to create the `LinkedList` class.
 


### PR DESCRIPTION
the methods "all" and "to_string" were used interchangeably through out, so I switched them all to "to_string". 

I noticed that Append is in the descritpion of iteration2, and shown in the code snippet contained within iteration2, but append is actually created in iteration1. I left it alone however since I wasn't sure if that was intentional.

-Changed "all" to "to_string" in jungle_beats.markdown
-Changed "all" to "to_string" in iteration1

@applegrain 