### PR TITLE
Adjust alphabetization on suggest method

### DIFF
--- a/source/projects/complete_me.markdown
+++ b/source/projects/complete_me.markdown
@@ -100,7 +100,7 @@ completion.count
 => 235886
 
 completion.suggest("piz")
-=> ["pizza", "pizzeria", "pizzicato", "pizzle", "pize"]
+=> ["pize", "pizza", "pizzeria", "pizzicato", "pizzle"]
 ```
 
 ### Usage Weighting


### PR DESCRIPTION
@rsbarbo and I noted that the return value of `completion.suggest("piz")` is no longer alphabetized, "pize" being after "pizzle." The spec doesn't explicitly state that it should be alphabetized, but as-is, the the expectation for the return value is inconsistent/hard to interpret. 

Thank you!
