### PR TITLE
Make credit_card_number an integer

### DIFF
--- a/source/projects/black_thursday/iteration_3.markdown
+++ b/source/projects/black_thursday/iteration_3.markdown
@@ -95,7 +95,7 @@ We create an instance like this:
 t = Transaction.new({
   :id => 6,
   :invoice_id => 8,
-  :credit_card_number => "4242424242424242",
+  :credit_card_number => 4242424242424242,
   :credit_card_expiration_date => "0220",
   :result => "success",
   :created_at => Time.now,


### PR DESCRIPTION
Changed the credit_card_number method in the Transaction class to return an integer so the spec aligns with the Spec Harness.