### PR TITLE
Change before_filter with before_action

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -2435,10 +2435,10 @@ Let's add in a protection scheme like this to the new users form:
 
 That way when the app is first setup we can create an account, then new users can only be created by a logged in user.
 
-We can create a `before_filter` which will run _before_ the `new` and `create` actions of our `authors_controller.rb`. Open that controller and put all this code in:
+We can create a `before_action` which will run _before_ the `new` and `create` actions of our `authors_controller.rb`. Open that controller and put all this code in:
 
 ```ruby
-before_filter :zero_authors_or_authenticated, only: [:new, :create]
+before_action :zero_authors_or_authenticated, only: [:new, :create]
 
 def zero_authors_or_authenticated
   unless Author.count == 0 || current_user
@@ -2461,12 +2461,12 @@ Then try to reach the registration form and it should work!  Create yourself an 
 
 ### Securing the Rest of the Application
 
-The first thing we need to do is sprinkle `before_filters` on most of our controllers:
+The first thing we need to do is sprinkle `before_actions` on most of our controllers:
 
-* In `authors_controller`, add a before filter to protect the actions besides `new` and `create` like this:<br/>`before_filter :require_login, except: [:new, :create]`
+* In `authors_controller`, add a before filter to protect the actions besides `new` and `create` like this:<br/>`before_action :require_login, except: [:new, :create]`
 * In `author_sessions_controller` all the methods need to be accessible to allow login and logout
-* In `tags_controller`, we need to prevent unauthenticated users from deleting the tags, so we protect just `destroy`. Since this is only a single action we can use `:only` like this:<br/>`before_filter :require_login, only: [:destroy]`
-* In `comments_controller`, we never implemented `index` and `destroy`, but just in case we do let's allow unauthenticated users to only access `create`:<br/>`before_filter :require_login, except: [:create]`
+* In `tags_controller`, we need to prevent unauthenticated users from deleting the tags, so we protect just `destroy`. Since this is only a single action we can use `:only` like this:<br/>`before_action :require_login, only: [:destroy]`
+* In `comments_controller`, we never implemented `index` and `destroy`, but just in case we do let's allow unauthenticated users to only access `create`:<br/>`before_action :require_login, except: [:create]`
 * In `articles_controller` authentication should be required for `new`, `create`, `edit`, `update` and `destroy`. Figure out how to write the before filter using either `:only` or `:except`
 
 Now our app is pretty secure, but we should hide all those edit, destroy, and new article links from unauthenticated users.


### PR DESCRIPTION
I tried `before_filter` and didn't work but `before_action` works. Also I've checked [here](https://stackoverflow.com/questions/45015651/undefined-method-for-before-filter) and found this:

before_filter has been deprecated in Rails 5.0 and removed in 5.1.