### PR TITLE
No Need To Install ImageMagick

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -1804,12 +1804,6 @@ These lines are commented out because they start with the `#` character. By spec
 ```ruby
 gem "paperclip"
 ```
-Paperclip is dependent on ImageMagick so you will also need to add that program.
-
-{% terminal %}
-$ brew install imagemagick
-{% endterminal %}
-
 When you're writing a production application, you might specify additional parameters that require a specific version or a custom source for the library. With that config line declared, go back to your terminal and run `rails server` to start the application again. You should get an error like this:
 
 {% terminal %}


### PR DESCRIPTION
Is Paperclip is only dependent on ImageMagick if you want to do some image manipulation, so you don't need to add that program unless you want to do image manipulation? As implied further on in this tutorial?

The tutorial also mentions it's tricky to install ImageMagick but we've already been asked to install it?

If this proposed change is not valid, maybe some clarification is required...