### PR TITLE
190120SU2309 updated multipart syntax & deleted broken link

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -1885,7 +1885,7 @@ First we'll add the ability to upload the file when editing the article, then we
 In the very first line, we need to specify that this form needs to accept "multipart" data. This is an instruction to the browser about how to submit the form. Change your top line so it looks like this:
 
 ```erb
-<%= form_for(@article, html: {multipart: true}) do |f| %>
+<%= form_for @article, :html => {:multipart => true} do |f| %>
 ```
 
 Then further down the form, right before the paragraph with the save button, let's add a label and field for the file uploading:
@@ -1899,7 +1899,7 @@ Then further down the form, right before the paragraph with the save button, let
 
 ### Trying it Out
 
-If your server isn't running, start it up (`rails server` in your terminal). Then go to `http://localhost:3000/articles/` and click EDIT for your first article. The file field should show up towards the bottom. Click the `Choose a File` and select a small image file (a suitable sample image can be found at http://hungryacademy.com/images/beast.png). Click SAVE and you'll return to the article index. Click the title of the article you just modified. What do you see?  Did the image attach to the article?
+If your server isn't running, start it up (`rails server` in your terminal). Then go to `http://localhost:3000/articles/` and click EDIT for your first article. The file field should show up towards the bottom. Click the `Choose a File` and select a small image file. Click SAVE and you'll return to the article index. Click the title of the article you just modified. What do you see?  Did the image attach to the article?
 
 When I first did this, I wasn't sure it worked. Here's how I checked:
 


### PR DESCRIPTION
`<%= form_for(@article, html: {multipart: true}) do |f| %>` gave syntax error. changed to `<%= form_for @article, :html => {:multipart => true} do |f| %>` based on Alston's answer at https://stackoverflow.com/questions/10526641/form-for-with-multipart-true-spits-out/10526674