### PR TITLE
rake routes deprecated in rails 6.1

### DIFF
--- a/source/projects/blogger.markdown
+++ b/source/projects/blogger.markdown
@@ -245,6 +245,8 @@ edit_article GET    /articles/:id/edit(.:format) articles#edit
              DELETE /articles/:id(.:format)      articles#destroy
 {% endterminal %}
 
+Note :- `rake routes` is deprectaed in rails 6.1,Use `rails routes` instead.
+
 Experiment with commenting out the `resources :articles` in `routes.rb` and running the command again. Un-comment the line after you see the results.
 
 These are the seven core actions of Rails' REST implementation. To understand the table, let's look at the first row as an example:


### PR DESCRIPTION
https://medium.com/progras/the-routes-task-expansion-in-rails-6-0-2b3468ab3485
`rake routes`  give an error now
`rails routes`  should be used instead